### PR TITLE
Simplify reduction tests

### DIFF
--- a/YololEmulator.Tests/Analysis/Reduction/ConstantFoldingTests.cs
+++ b/YololEmulator.Tests/Analysis/Reduction/ConstantFoldingTests.cs
@@ -7,60 +7,27 @@ namespace YololEmulator.Tests.Analysis.Reduction
     [TestClass]
     public class ConstantFoldingTests
     {
-        [TestMethod]
-        public void FoldNumber()
-        {
-            var ast = TestExecutor.Parse("a=-2+(2*3)/2");
-            var reduced = ast.FoldConstants().ToString();
-            Assert.AreEqual("a=1", reduced);
-        }
+        private static ReducerTestHelper helper = new ReducerTestHelper(ast => ast.FoldConstants());
 
         [TestMethod]
-        public void FoldString()
-        {
-            var ast = Parser.TryParseProgram(Tokenizer.TryTokenize("a=\"sss\"+\"qqq\"").Value).Value;
-            var reduced = ast.FoldConstants().ToString();
-            Assert.AreEqual("a=\"sssqqq\"", reduced);
-        }
+        public void FoldNumber() => helper.Run("a=-2+(2*3)/2", "a=1");
 
         [TestMethod]
-        public void DoNotFoldExternals()
-        {
-            var ast = Parser.TryParseProgram(Tokenizer.TryTokenize("a=:extern+3").Value).Value;
-            var reduced = ast.FoldConstants().ToString();
-            Assert.AreEqual("a=:extern+3", reduced);
-        }
+        public void FoldString() => helper.Run("a=\"sss\"+\"qqq\"", "a=\"sssqqq\"");
 
         [TestMethod]
-        public void FoldIfTrue()
-        {
-            var ast = Parser.TryParseProgram(Tokenizer.TryTokenize("if 1 then a = 1 else a = 2 end").Value).Value;
-            var reduced = ast.FoldConstants().ToString();
-            Assert.AreEqual("a=1", reduced);
-        }
+        public void DoNotFoldExternals() => helper.Run("a=:extern+3", "a=:extern+3");
 
         [TestMethod]
-        public void FoldIfFalse()
-        {
-            var ast = TestExecutor.Parse("if 0 then a = 1 else a = 2 end");
-            var reduced = ast.FoldConstants().ToString();
-            Assert.AreEqual("a=2", reduced);
-        }
+        public void FoldIfTrue() => helper.Run("if 1 then a = 1 else a = 2 end", "a=1");
 
         [TestMethod]
-        public void DoNotFoldIf()
-        {
-            var ast = TestExecutor.Parse("if :extern then a = 1 else a = 2 end");
-            var reduced = ast.FoldConstants().ToString();
-            Assert.AreEqual("if :extern then a=1 else a=2 end", reduced);
-        }
+        public void FoldIfFalse() => helper.Run("if 0 then a = 1 else a = 2 end", "a=2");
 
         [TestMethod]
-        public void DoNotFoldIfError()
-        {
-            var ast = TestExecutor.Parse("if \"err\" then a = 1 else a = 2 end");
-            var reduced = ast.FoldConstants().ToString();
-            Assert.AreEqual("if \"err\" then a=1 else a=2 end", reduced);
-        }
+        public void DoNotFoldIf() => helper.Run("if :extern then a = 1 else a = 2 end", "if :extern then a=1 else a=2 end");
+
+        [TestMethod]
+        public void DoNotFoldIfError() => helper.Run("if \"err\" then a = 1 else a = 2 end", "if \"err\" then a=1 else a=2 end");
     }
 }

--- a/YololEmulator.Tests/Analysis/Reduction/DeadAfterGotoTests.cs
+++ b/YololEmulator.Tests/Analysis/Reduction/DeadAfterGotoTests.cs
@@ -6,28 +6,18 @@ namespace YololEmulator.Tests.Analysis.Reduction
     [TestClass]
     public class DeadAfterGotoTests
     {
-        [TestMethod]
-        public void BasicElimination()
-        {
-            var ast = TestExecutor.Parse("a=1 goto 2 a=3");
-            var reduced = ast.DeadPostGotoElimination().ToString();
-            Assert.AreEqual("a=1 goto 2", reduced);
-        }
+        private static ReducerTestHelper helper = new ReducerTestHelper(ast => ast.DeadPostGotoElimination());
 
         [TestMethod]
-        public void GotoInsideIfIfElimination()
-        {
-            var ast = TestExecutor.Parse("a=1 if :b then goto 2 a=4 else a=3 end");
-            var reduced = ast.DeadPostGotoElimination().ToString();
-            Assert.AreEqual("a=1 if :b then goto 2 end a=3", reduced);
-        }
+        public void BasicElimination() => helper.Run("a=1 goto 2 a=3", "a=1 goto 2");
 
         [TestMethod]
-        public void GotoInTrueBranch()
-        {
-            var ast = TestExecutor.Parse("if :b then goto 2 else a=3 end");
-            var reduced = ast.DeadPostGotoElimination().ToString();
-            Assert.AreEqual("if :b then goto 2 end a=3", reduced);
-        }
+        public void GotoAfterGotoElimination() => helper.Run("a=1 goto 2 goto 3 a=3", "a=1 goto 2");
+
+        [TestMethod]
+        public void GotoInsideIfIfElimination() => helper.Run("a=1 if :b then goto 2 a=4 else a=3 end", "a=1 if :b then goto 2 end a=3");
+
+        [TestMethod]
+        public void GotoInTrueBranch() => helper.Run("if :b then goto 2 else a=3 end", "if :b then goto 2 end a=3");
     }
 }

--- a/YololEmulator.Tests/Analysis/Reduction/FlattenStatementListsTests.cs
+++ b/YololEmulator.Tests/Analysis/Reduction/FlattenStatementListsTests.cs
@@ -10,16 +10,11 @@ namespace YololEmulator.Tests.Analysis.Reduction
     [TestClass]
     public class FlattenStatementListsTests
     {
+        private static ReducerTestHelper helper = new ReducerTestHelper(ast => new FlattenStatementLists().Visit(ast));
+
         [TestMethod]
-        public void Flatten()
-        {
-            var ast = new Program(new Line[] {
-                new Line(new StatementList(new Assignment(new VariableName("a"), new Sine(new Variable(new VariableName("b"))))))
-            });
-
-            var r = new FlattenStatementLists().Visit(ast).ToString();
-
-            Assert.AreEqual("a=sin(b)", r);
-        }
+        public void Flatten() => helper.Run("a=sin(b)", new Program(new Line[] {
+            new Line(new StatementList(new Assignment(new VariableName("a"), new Sine(new Variable(new VariableName("b"))))))
+        }));
     }
 }

--- a/YololEmulator.Tests/Analysis/Reduction/ReducerTestHelper.cs
+++ b/YololEmulator.Tests/Analysis/Reduction/ReducerTestHelper.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Yolol.Grammar.AST;
+
+namespace YololEmulator.Tests.Analysis.Reduction
+{
+    class ReducerTestHelper
+    {
+        private Func<Program, Program> reducer;
+
+        public ReducerTestHelper(System.Func<Program, Program> reducer)
+        {
+            this.reducer = reducer;
+        }
+
+        public void Run(string inputYolol, string expectedReducedYolol) => Run(inputYolol, expectedReducedYolol, reducer);
+
+        public void Run(Program inputAst, string expectedReducedYolol) => Run(inputAst, expectedReducedYolol, reducer);
+
+        public void Run(string inputYolol, Program expectedReducedYolol) => Run(inputYolol, expectedReducedYolol, reducer);
+
+        public void Run(Program inputAst, Program expectedReducedAst) => Run(inputAst, expectedReducedAst, reducer);
+
+        public static void Run(string inputYolol, string expectedReducedYolol, Func<Program, Program> reducer)
+        {
+            var inputAst = TestExecutor.Parse(inputYolol);
+            var expectedReducedAst = TestExecutor.Parse(expectedReducedYolol);
+
+            Run(inputAst, expectedReducedAst, reducer);
+        }
+
+        public static void Run(Program inputAst, string expectedReducedYolol, Func<Program, Program> reducer)
+        {
+            var expectedReducedAst = TestExecutor.Parse(expectedReducedYolol);
+
+            Run(inputAst, expectedReducedAst, reducer);
+        }
+
+        public static void Run(string inputYolol, Program expectedReducedAst, Func<Program, Program> reducer)
+        {
+            var inputAst = TestExecutor.Parse(inputYolol);
+
+            Run(inputAst, expectedReducedAst, reducer);
+        }
+
+        public static void Run(Program inputAst, Program expectedReducedAst, Func<Program, Program> reducer)
+        {
+            var reducedAst = reducer(inputAst);
+
+            Assert.IsTrue(expectedReducedAst.Equals(reducedAst));
+        }
+    }
+}

--- a/YololEmulator.Tests/Analysis/Reduction/VariableSimplificationTests.cs
+++ b/YololEmulator.Tests/Analysis/Reduction/VariableSimplificationTests.cs
@@ -9,31 +9,13 @@ namespace YololEmulator.Tests.Analysis.Reduction
     [TestClass]
     public class VariableSimplificationTests
     {
-        [TestMethod]
-        public void SimplifyVarNames()
-        {
-            // Parse the initial (complex) code
-            var ast = TestExecutor.Parse("ship=7", "ixf=0 ship=6");
-
-            // Reduce AST to a simpler program
-            var reduced = ast.SimplifyVariableNames().ToString();
-
-            // Check we got the simpler program we expected
-            Assert.AreEqual("a=7\nb=0 a=6", reduced);
-        }
+        private static ReducerTestHelper helper = new ReducerTestHelper(ast => ast.SimplifyVariableNames());
 
         [TestMethod]
-        public void PreserveExternalNames()
-        {
-            // Parse the initial (complex) code
-            var ast = Parser.TryParseProgram(Tokenizer.TryTokenize("ship=7 :counter=0 ship=6").Value).Value;
+        public void SimplifyVarNames() => helper.Run("ship=7\nixf=0 ship=6", "a=7\nb=0 a=6");
 
-            // Reduce AST to a simpler program
-            var reduced = ast.SimplifyVariableNames().ToString();
-
-            // Check we got the simpler program we expected
-            Assert.AreEqual("a=7 :counter=0 a=6", reduced);
-        }
+        [TestMethod]
+        public void PreserveExternalNames() => helper.Run("ship=7 :counter=0 ship=6", "a=7 :counter=0 a=6");
 
         [TestMethod]
         public void LotsOfUniqueNames()


### PR DESCRIPTION
# Preface
Some might consider the changes I'm proposing here to be a case of overengineering. I don't consider this to be the case, as I believe we should strive to avoid human errors. One way to avoid human errors is the concept of **DRY** (Don't Repeat Yourself). The changes I'm proposing allow for this by reducing the amount of repeated code throughout the testing codebase.
# Summary
I have replaced (most) reduction tests with single calls to a helper function which parses the code and compares the outputs after the input has been optimized.
# Documentation
## `ReducerTestHelper`
### Constructors
#### `ReducerTestHelper(System.Func<Yolol.Grammar.AST.Program, Yolol.Grammar.AST.Program> reducer)`
Creates a helper that will reduce the inputs using the `reducer` function.
### Instance methods
#### `void Run(string inputYolol, string expectedReducedYolol)`
Runs the test and asserts whether the reduced AST equals the expected AST.
#### `void Run(Yolol.Grammar.AST.Program inputAst, string expectedReducedYolol)`
See `void Run(string inputYolol, string expectedReducedYolol)`.
#### `void Run(string inputYolol, Yolol.Grammar.AST.Program expectedReducedAst)`
See `void Run(string inputYolol, string expectedReducedYolol)`.
#### `void Run(Yolol.Grammar.AST.Program inputAst, Yolol.Grammar.AST.Program expectedReducedAst)`
See `void Run(string inputYolol, string expectedReducedYolol)`.
### Static methods
#### `void Run(string inputYolol, string expectedReducedYolol, System.Func<Yolol.Grammar.AST.Program, Yolol.Grammar.AST.Program> reducer)`
Runs the test and asserts whether the reduced AST equals the expected AST.
#### `void Run(Yolol.Grammar.AST.Program inputAst, string expectedReducedYolol, System.Func<Yolol.Grammar.AST.Program, Yolol.Grammar.AST.Program> reducer)`
See `void Run(string inputYolol, string expectedReducedYolol, System.Func<Yolol.Grammar.AST.Program, Yolol.Grammar.AST.Program> reducer)`.
#### `void Run(string inputYolol, Yolol.Grammar.AST.Program expectedReducedAst, System.Func<Yolol.Grammar.AST.Program, Yolol.Grammar.AST.Program> reducer)`
See `void Run(string inputYolol, string expectedReducedYolol, System.Func<Yolol.Grammar.AST.Program, Yolol.Grammar.AST.Program> reducer)`.
#### `void Run(Yolol.Grammar.AST.Program inputAst, Yolol.Grammar.AST.Program expectedReducedAst, System.Func<Yolol.Grammar.AST.Program, Yolol.Grammar.AST.Program> reducer)`
See `void Run(string inputYolol, string expectedReducedYolol, System.Func<Yolol.Grammar.AST.Program, Yolol.Grammar.AST.Program> reducer)`.