### PR TITLE
Add YASM Cheatsheet

### DIFF
--- a/YololAssembler/cheatsheet.md
+++ b/YololAssembler/cheatsheet.md
@@ -1,0 +1,47 @@
+# YASM quick reference
+
+## Lines
+```
+@line-label:
+	## code goes here. "##" is a comment.
+```
+- `@:` unlabeled lines also work, if you never need to jump to them!
+- `@` alone is replaced with the current line. `goto@`
+
+## Spacing
+
+- Spaces / tabs in front of a line are ignored.
+- Newlines are ignored. Empty or comment lines are ignored.
+- ; is replaced with a space: meant to replace spaces at the end of a line.
+- Spaces before a comment are ignored. *(**`a=1  ##`** won't add a space)*
+- {} are removed after macro replacement. `goto{line} == gotoline`
+
+## Defines
+
+Defines let you create macros.
+```
+#define LongMacroName a
+## LongMacroName=1    => a=1
+
+#define functionname(arg1, arg2) arg1+=arg2
+## functionname(x, 2) => x+=2
+
+#define longfunc(arg1, arg2, arg3) {
+    arg1+=arg2;
+    arg1/=arg3
+}
+## longfunc(a, b, c)  => a+=b a/=c
+```
+
+## Imports
+
+Imports let you take the **#define**s of another file and use them.
+
+This doesn't just copy paste *everything*: YOLOL lines are ignored.
+
+```
+#import lib.yasm
+
+@:
+	continue_if(1==2)
+```

--- a/YololAssembler/readme.md
+++ b/YololAssembler/readme.md
@@ -167,3 +167,7 @@ This could match `foo` and `bar`, or it could match `foobar`. To fix this:
 @:
     x={foo}{bar}
 ```
+
+## Cheatsheet
+
+For a compact YASM reference, open `cheatsheet.md`.


### PR DESCRIPTION
This is a smaller reference file for YASM, it assumes you already know how to use it, but is more compact and focuses on sintax and "oh hey, this feature exists".
There is also a small mention about this file in the readme.md.
Change this as you see fit. 
Information is based on the reference found in readme.md, but it's always possible that i've made a mistake or two. A quick check might be good.